### PR TITLE
Add convenience showWithStatus:maskType:fromView:.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -63,6 +63,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDMaskType) {
 
 + (void)showErrorWithStatus:(NSString *)string;
 + (void)showErrorWithStatus:(NSString *)string maskType:(SVProgressHUDMaskType)maskType;
++ (void)showErrorWithStatus:(NSString *)string maskType:(SVProgressHUDMaskType)maskType fromView:(UIView *)aView;
 
 // use 28x28 white pngs
 + (void)showImage:(UIImage*)image status:(NSString*)status;

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDMaskType) {
 + (void)showWithMaskType:(SVProgressHUDMaskType)maskType;
 + (void)showWithStatus:(NSString*)status;
 + (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
++ (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType fromView:(UIView *)aView;
 
 + (void)showProgress:(float)progress;
 + (void)showProgress:(float)progress maskType:(SVProgressHUDMaskType)maskType;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -211,6 +211,12 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     [self showImage:SVProgressHUDErrorImage status:string maskType:maskType];
 }
 
++ (void)showErrorWithStatus:(NSString *)string maskType:(SVProgressHUDMaskType)maskType fromView:(UIView *)aView {
+    SVProgressHUD *progressView = [self sharedView];
+    [aView addSubview:progressView];
+    [self showImage:SVProgressHUDErrorImage status:string maskType:maskType];
+}
+
 + (void)showImage:(UIImage *)image status:(NSString *)string {
     [self sharedView];
     [self showImage:image status:string maskType:SVProgressHUDDefaultMaskType];

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -154,6 +154,12 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     [self showProgress:SVProgressHUDUndefinedProgress status:status maskType:maskType];
 }
 
++ (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType fromView:(UIView *)aView {
+    SVProgressHUD *progressView = [self sharedView];
+    [aView addSubview:progressView];
+    [progressView showProgress:SVProgressHUDUndefinedProgress status:status maskType:maskType];
+}
+
 + (void)showProgress:(float)progress {
     [self sharedView];
     [self showProgress:progress maskType:SVProgressHUDDefaultMaskType];


### PR DESCRIPTION
This is for the simple showWithStatus method, so it could be duplicated for showing success, progress, or error. This fix was inspired because I had a collection view that was blocking the HUD in the hierarchy. Please feel free to accept, reject, or use as inspiration for a different type of update. 