### PR TITLE
Fix image paths to support frameworks (and Swift) introduced in Cocoapods 0.36 beta

### DIFF
--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -29,7 +29,7 @@
 
 - (void)layoutAnimatedLayer {
     CALayer *layer = self.indefiniteAnimatedLayer;
-    
+
     [self.layer addSublayer:layer];
     layer.position = CGPointMake(CGRectGetWidth(self.bounds) - CGRectGetWidth(layer.bounds) / 2, CGRectGetHeight(self.bounds) - CGRectGetHeight(layer.bounds) / 2);
 }
@@ -38,13 +38,13 @@
     if(!_indefiniteAnimatedLayer) {
         CGPoint arcCenter = CGPointMake(self.radius+self.strokeThickness/2+5, self.radius+self.strokeThickness/2+5);
         CGRect rect = CGRectMake(0.0f, 0.0f, arcCenter.x*2, arcCenter.y*2);
-        
+
         UIBezierPath* smoothedPath = [UIBezierPath bezierPathWithArcCenter:arcCenter
                                                                     radius:self.radius
                                                                 startAngle:M_PI*3/2
                                                                   endAngle:M_PI/2+M_PI*5
                                                                  clockwise:YES];
-        
+
         _indefiniteAnimatedLayer = [CAShapeLayer layer];
         _indefiniteAnimatedLayer.contentsScale = [[UIScreen mainScreen] scale];
         _indefiniteAnimatedLayer.frame = rect;
@@ -54,15 +54,17 @@
         _indefiniteAnimatedLayer.lineCap = kCALineCapRound;
         _indefiniteAnimatedLayer.lineJoin = kCALineJoinBevel;
         _indefiniteAnimatedLayer.path = smoothedPath.CGPath;
-        
+
         CALayer *maskLayer = [CALayer layer];
-        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask"] CGImage];
+
+        NSBundle* bundle = [NSBundle bundleForClass:self.class];
+        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask" inBundle:bundle compatibleWithTraitCollection:nil] CGImage];
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;
-        
+
         NSTimeInterval animationDuration = 1;
         CAMediaTimingFunction *linearCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
-        
+
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"transform.rotation"];
         animation.fromValue = 0;
         animation.toValue = [NSNumber numberWithFloat:M_PI*2];
@@ -73,31 +75,31 @@
         animation.fillMode = kCAFillModeForwards;
         animation.autoreverses = NO;
         [_indefiniteAnimatedLayer.mask addAnimation:animation forKey:@"rotate"];
-        
+
         CAAnimationGroup *animationGroup = [CAAnimationGroup animation];
         animationGroup.duration = animationDuration;
         animationGroup.repeatCount = INFINITY;
         animationGroup.removedOnCompletion = NO;
         animationGroup.timingFunction = linearCurve;
-        
+
         CABasicAnimation *strokeStartAnimation = [CABasicAnimation animationWithKeyPath:@"strokeStart"];
         strokeStartAnimation.fromValue = @0.015;
         strokeStartAnimation.toValue = @0.515;
-        
+
         CABasicAnimation *strokeEndAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
         strokeEndAnimation.fromValue = @0.485;
         strokeEndAnimation.toValue = @0.985;
-        
+
         animationGroup.animations = @[strokeStartAnimation, strokeEndAnimation];
         [_indefiniteAnimatedLayer addAnimation:animationGroup forKey:@"progress"];
-        
+
     }
     return _indefiniteAnimatedLayer;
 }
 
 - (void)setFrame:(CGRect)frame {
     [super setFrame:frame];
-    
+
     if (self.superview) {
         [self layoutAnimatedLayer];
     }
@@ -105,10 +107,10 @@
 
 - (void)setRadius:(CGFloat)radius {
     _radius = radius;
-    
+
     [_indefiniteAnimatedLayer removeFromSuperlayer];
     _indefiniteAnimatedLayer = nil;
-    
+
     if (self.superview) {
         [self layoutAnimatedLayer];
     }

--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -29,7 +29,7 @@
 
 - (void)layoutAnimatedLayer {
     CALayer *layer = self.indefiniteAnimatedLayer;
-
+    
     [self.layer addSublayer:layer];
     layer.position = CGPointMake(CGRectGetWidth(self.bounds) - CGRectGetWidth(layer.bounds) / 2, CGRectGetHeight(self.bounds) - CGRectGetHeight(layer.bounds) / 2);
 }
@@ -38,13 +38,13 @@
     if(!_indefiniteAnimatedLayer) {
         CGPoint arcCenter = CGPointMake(self.radius+self.strokeThickness/2+5, self.radius+self.strokeThickness/2+5);
         CGRect rect = CGRectMake(0.0f, 0.0f, arcCenter.x*2, arcCenter.y*2);
-
+        
         UIBezierPath* smoothedPath = [UIBezierPath bezierPathWithArcCenter:arcCenter
                                                                     radius:self.radius
                                                                 startAngle:M_PI*3/2
                                                                   endAngle:M_PI/2+M_PI*5
                                                                  clockwise:YES];
-
+        
         _indefiniteAnimatedLayer = [CAShapeLayer layer];
         _indefiniteAnimatedLayer.contentsScale = [[UIScreen mainScreen] scale];
         _indefiniteAnimatedLayer.frame = rect;
@@ -54,17 +54,17 @@
         _indefiniteAnimatedLayer.lineCap = kCALineCapRound;
         _indefiniteAnimatedLayer.lineJoin = kCALineJoinBevel;
         _indefiniteAnimatedLayer.path = smoothedPath.CGPath;
-
+        
         CALayer *maskLayer = [CALayer layer];
-
+        
         NSBundle* bundle = [NSBundle bundleForClass:self.class];
         maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask" inBundle:bundle compatibleWithTraitCollection:nil] CGImage];
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;
-
+        
         NSTimeInterval animationDuration = 1;
         CAMediaTimingFunction *linearCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
-
+        
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"transform.rotation"];
         animation.fromValue = 0;
         animation.toValue = [NSNumber numberWithFloat:M_PI*2];
@@ -75,31 +75,31 @@
         animation.fillMode = kCAFillModeForwards;
         animation.autoreverses = NO;
         [_indefiniteAnimatedLayer.mask addAnimation:animation forKey:@"rotate"];
-
+        
         CAAnimationGroup *animationGroup = [CAAnimationGroup animation];
         animationGroup.duration = animationDuration;
         animationGroup.repeatCount = INFINITY;
         animationGroup.removedOnCompletion = NO;
         animationGroup.timingFunction = linearCurve;
-
+        
         CABasicAnimation *strokeStartAnimation = [CABasicAnimation animationWithKeyPath:@"strokeStart"];
         strokeStartAnimation.fromValue = @0.015;
         strokeStartAnimation.toValue = @0.515;
-
+        
         CABasicAnimation *strokeEndAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
         strokeEndAnimation.fromValue = @0.485;
         strokeEndAnimation.toValue = @0.985;
-
+        
         animationGroup.animations = @[strokeStartAnimation, strokeEndAnimation];
         [_indefiniteAnimatedLayer addAnimation:animationGroup forKey:@"progress"];
-
+        
     }
     return _indefiniteAnimatedLayer;
 }
 
 - (void)setFrame:(CGRect)frame {
     [super setFrame:frame];
-
+    
     if (self.superview) {
         [self layoutAnimatedLayer];
     }
@@ -107,10 +107,10 @@
 
 - (void)setRadius:(CGFloat)radius {
     _radius = radius;
-
+    
     [_indefiniteAnimatedLayer removeFromSuperlayer];
     _indefiniteAnimatedLayer = nil;
-
+    
     if (self.superview) {
         [self layoutAnimatedLayer];
     }

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -263,9 +263,9 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
         }
 
         NSBundle* bundle = [NSBundle bundleForClass:self.class];
-        UIImage* infoImage = [UIImage imageNamed:@"info" inBundle:bundle compatibleWithTraitCollection:nil];
-        UIImage* successImage = [UIImage imageNamed:@"success" inBundle:bundle compatibleWithTraitCollection:nil];
-        UIImage* errorImage = [UIImage imageNamed:@"error" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* infoImage = [UIImage imageNamed:@"SVProgressHUD.bundle/info" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* errorImage = [UIImage imageNamed:@"SVProgressHUD.bundle/error" inBundle:bundle compatibleWithTraitCollection:nil];
 
         if ([[UIImage class] instancesRespondToSelector:@selector(imageWithRenderingMode:)]) {
             SVProgressHUDInfoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -261,15 +261,22 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
             SVProgressHUDBackgroundColor = [UIColor colorWithWhite:0.0f alpha:0.8f];
             SVProgressHUDForegroundColor = [UIColor whiteColor];
         }
+
+        NSBundle* bundle = [NSBundle bundleForClass:self.class];
+        UIImage* infoImage = [UIImage imageNamed:@"info" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* successImage = [UIImage imageNamed:@"success" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* errorImage = [UIImage imageNamed:@"error" inBundle:bundle compatibleWithTraitCollection:nil];
+
         if ([[UIImage class] instancesRespondToSelector:@selector(imageWithRenderingMode:)]) {
-            SVProgressHUDInfoImage = [[UIImage imageNamed:@"SVProgressHUD.bundle/info"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-            SVProgressHUDSuccessImage = [[UIImage imageNamed:@"SVProgressHUD.bundle/success"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-            SVProgressHUDErrorImage = [[UIImage imageNamed:@"SVProgressHUD.bundle/error"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+            SVProgressHUDInfoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+            SVProgressHUDSuccessImage = [successImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+            SVProgressHUDErrorImage = [errorImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         } else {
-            SVProgressHUDInfoImage = [UIImage imageNamed:@"SVProgressHUD.bundle/info"];
-            SVProgressHUDSuccessImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success"];
-            SVProgressHUDErrorImage = [UIImage imageNamed:@"SVProgressHUD.bundle/error"];
+            SVProgressHUDInfoImage = infoImage;
+            SVProgressHUDSuccessImage = successImage;
+            SVProgressHUDErrorImage = errorImage;
         }
+
         SVProgressHUDRingThickness = 2;
         SVProgressHUDDefaultMaskType = SVProgressHUDMaskTypeNone;
     }


### PR DESCRIPTION
This fixes #396 for Cocoapods 0.36 beta. I didn't yet have time to test this on a static library setup, but it works nicely in my Swift application. 

There's some whitespace cleanup automatically done by the editor.
