### PR TITLE
Load images in class bundle starting from iOS 8

### DIFF
--- a/SVProgressHUD.xcodeproj/project.pbxproj
+++ b/SVProgressHUD.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		65F0220015C857EF0030BBEF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65F021FF15C857EF0030BBEF /* Foundation.framework */; };
 		65F0220515C857EF0030BBEF /* SVProgressHUD.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 65F0220415C857EF0030BBEF /* SVProgressHUD.h */; };
 		65F0220715C857EF0030BBEF /* SVProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F0220615C857EF0030BBEF /* SVProgressHUD.m */; };
+		C0737C661A9321F000E7E084 /* UIImage+Framework.m in Sources */ = {isa = PBXBuildFile; fileRef = C0737C651A9321F000E7E084 /* UIImage+Framework.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,6 +33,8 @@
 		65F0220415C857EF0030BBEF /* SVProgressHUD.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVProgressHUD.h; sourceTree = "<group>"; };
 		65F0220615C857EF0030BBEF /* SVProgressHUD.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVProgressHUD.m; sourceTree = "<group>"; };
 		65F0220D15C858060030BBEF /* SVProgressHUD.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = SVProgressHUD.bundle; sourceTree = "<group>"; };
+		C0737C641A9321F000E7E084 /* UIImage+Framework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Framework.h"; sourceTree = "<group>"; };
+		C0737C651A9321F000E7E084 /* UIImage+Framework.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Framework.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +79,8 @@
 			children = (
 				65F0220415C857EF0030BBEF /* SVProgressHUD.h */,
 				65F0220615C857EF0030BBEF /* SVProgressHUD.m */,
+				C0737C641A9321F000E7E084 /* UIImage+Framework.h */,
+				C0737C651A9321F000E7E084 /* UIImage+Framework.m */,
 				65F0220D15C858060030BBEF /* SVProgressHUD.bundle */,
 				65F0220215C857EF0030BBEF /* Supporting Files */,
 			);
@@ -141,6 +146,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0737C661A9321F000E7E084 /* UIImage+Framework.m in Sources */,
 				65F0220715C857EF0030BBEF /* SVProgressHUD.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -56,7 +56,8 @@
         _indefiniteAnimatedLayer.path = smoothedPath.CGPath;
         
         CALayer *maskLayer = [CALayer layer];
-        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask"] CGImage];
+        NSBundle* bundle = UIDevice.currentDevice.systemVersion.floatValue >= 8.0 ? [NSBundle bundleForClass:self.class] : nil;
+        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask" inBundle:bundle compatibleWithTraitCollection:nil] CGImage];
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;
         

--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -7,6 +7,8 @@
 //
 
 #import "SVIndefiniteAnimatedView.h"
+#import "SVProgressHUD.h"
+#import "UIImage+Framework.h"
 
 #pragma mark SVIndefiniteAnimatedView
 
@@ -56,8 +58,7 @@
         _indefiniteAnimatedLayer.path = smoothedPath.CGPath;
         
         CALayer *maskLayer = [CALayer layer];
-        NSBundle* bundle = UIDevice.currentDevice.systemVersion.floatValue >= 8.0 ? [NSBundle bundleForClass:self.class] : nil;
-        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask" inBundle:bundle compatibleWithTraitCollection:nil] CGImage];
+        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask" classInFramework:self.class] CGImage];
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;
         

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -262,9 +262,12 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
             SVProgressHUDForegroundColor = [UIColor whiteColor];
         }
         
-        UIImage* infoImage = [UIImage imageNamed:@"SVProgressHUD.bundle/info"];
-        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success"];
-        UIImage* errorImage = [UIImage imageNamed:@"SVProgressHUD.bundle/error"];
+        // Defines the bundle where images are located. Starting from iOS 8.0+, it's in the bundle defined by the current class.
+        NSBundle* bundle = UIDevice.currentDevice.systemVersion.floatValue >= 8.0 ? [NSBundle bundleForClass:self.class] : nil;
+        
+        UIImage* infoImage    = [UIImage imageNamed:@"SVProgressHUD.bundle/info" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* errorImage   = [UIImage imageNamed:@"SVProgressHUD.bundle/error" inBundle:bundle compatibleWithTraitCollection:nil];
 
         if ([[UIImage class] instancesRespondToSelector:@selector(imageWithRenderingMode:)]) {
             SVProgressHUDInfoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -12,6 +12,7 @@
 
 #import "SVProgressHUD.h"
 #import "SVIndefiniteAnimatedView.h"
+#import "UIImage+Framework.h"
 #import <QuartzCore/QuartzCore.h>
 
 NSString * const SVProgressHUDDidReceiveTouchEventNotification = @"SVProgressHUDDidReceiveTouchEventNotification";
@@ -262,12 +263,9 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
             SVProgressHUDForegroundColor = [UIColor whiteColor];
         }
         
-        // Defines the bundle where images are located. Starting from iOS 8.0+, it's in the bundle defined by the current class.
-        NSBundle* bundle = UIDevice.currentDevice.systemVersion.floatValue >= 8.0 ? [NSBundle bundleForClass:self.class] : nil;
-        
-        UIImage* infoImage    = [UIImage imageNamed:@"SVProgressHUD.bundle/info" inBundle:bundle compatibleWithTraitCollection:nil];
-        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success" inBundle:bundle compatibleWithTraitCollection:nil];
-        UIImage* errorImage   = [UIImage imageNamed:@"SVProgressHUD.bundle/error" inBundle:bundle compatibleWithTraitCollection:nil];
+        UIImage* infoImage    = [UIImage imageNamed:@"SVProgressHUD.bundle/info" classInFramework:self.class];
+        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success" classInFramework:self.class];
+        UIImage* errorImage   = [UIImage imageNamed:@"SVProgressHUD.bundle/error" classInFramework:self.class];
 
         if ([[UIImage class] instancesRespondToSelector:@selector(imageWithRenderingMode:)]) {
             SVProgressHUDInfoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/SVProgressHUD/UIImage+Framework.h
+++ b/SVProgressHUD/UIImage+Framework.h
@@ -1,0 +1,15 @@
+//
+//  UIImage+Framework.h
+//  SVProgressHUD
+//
+//  Created by Loïs Di Qual on 2/16/15.
+//  Copyright (c) 2015 EmbeddedSources. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Framework)
+
++ (UIImage *)imageNamed:(NSString *)name classInFramework:(Class)aClass;
+
+@end

--- a/SVProgressHUD/UIImage+Framework.m
+++ b/SVProgressHUD/UIImage+Framework.m
@@ -1,0 +1,22 @@
+//
+//  UIImage+Framework.m
+//  SVProgressHUD
+//
+//  Created by Loïs Di Qual on 2/16/15.
+//  Copyright (c) 2015 EmbeddedSources. All rights reserved.
+//
+
+#import "UIImage+Framework.h"
+
+@implementation UIImage (Framework)
+
++ (UIImage *)imageNamed:(NSString *)name classInFramework:(Class)aClass {
+    if ([UIImage respondsToSelector:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
+        NSBundle* bundle = [NSBundle bundleForClass:aClass];
+        return [UIImage imageNamed:name inBundle:bundle compatibleWithTraitCollection:nil];
+    }
+    
+    return [UIImage imageNamed:name];
+}
+
+@end


### PR DESCRIPTION
Fixes https://github.com/TransitApp/SVProgressHUD/issues/396

In order to support loading from the main bundle on iOS 7.0, this PR selects the right bundle to load images from dynamically.

@honkmaster I couldn't test this on iOS 7.0, would you mind taking a look at it?