### PR TITLE
Fixes Frameworks' image-loading issue.

### DIFF
--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -56,7 +56,13 @@
         _indefiniteAnimatedLayer.path = smoothedPath.CGPath;
         
         CALayer *maskLayer = [CALayer layer];
-        maskLayer.contents = (id)[[UIImage imageNamed:@"SVProgressHUD.bundle/angle-mask"] CGImage];
+        
+        NSBundle *bundle = [NSBundle bundleForClass:self.class];
+        NSURL *url = [bundle URLForResource:@"SVProgressHUD" withExtension:@"bundle"];
+        NSBundle *imageBundle = [NSBundle bundleWithURL:url];
+        NSString *path = [imageBundle pathForResource:@"angle-mask" ofType:@"png"];
+        
+        maskLayer.contents = (id)[[UIImage imageWithContentsOfFile:path] CGImage];;
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;
         

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -262,9 +262,13 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
             SVProgressHUDForegroundColor = [UIColor whiteColor];
         }
         
-        UIImage* infoImage = [UIImage imageNamed:@"SVProgressHUD.bundle/info"];
-        UIImage* successImage = [UIImage imageNamed:@"SVProgressHUD.bundle/success"];
-        UIImage* errorImage = [UIImage imageNamed:@"SVProgressHUD.bundle/error"];
+        NSBundle *bundle = [NSBundle bundleForClass:self.class];
+        NSURL *url = [bundle URLForResource:@"SVProgressHUD" withExtension:@"bundle"];
+        NSBundle *imageBundle = [NSBundle bundleWithURL:url];
+        
+        UIImage* infoImage = [UIImage imageWithContentsOfFile:[imageBundle pathForResource:@"info" ofType:@"png"]];
+        UIImage* successImage = [UIImage imageWithContentsOfFile:[imageBundle pathForResource:@"success" ofType:@"png"]];
+        UIImage* errorImage = [UIImage imageWithContentsOfFile:[imageBundle pathForResource:@"error" ofType:@"png"]];
 
         if ([[UIImage class] instancesRespondToSelector:@selector(imageWithRenderingMode:)]) {
             SVProgressHUDInfoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];


### PR DESCRIPTION
Hi there! Long-time user, first-time contributor :iphone: 

The behaviour of `imageNamed:` has changed in version 0.36 of CocoaPods (which is currently in RC 1). [This blog post](http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/) has some more details. 

Long story short: `imageNamed:` won't work in the way that the library is using them; they need to be loaded directly from the file system, instead. 

This is in lieu of #403 because I didn't see it before I made my changes, because its implementation is a bit heavy-handed, and because it is incomplete (doesn't work in the indefinite animated view class).

I'm happy to modify the code style or structure to get it merged – just let me know!

Fixes #396. 