### PR TITLE
Fixes the issues that popActivity method does not work sometimes.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -614,6 +614,9 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     if(!self.superview)
         [self.overlayView addSubview:self];
     
+    if(self.fadeOutTimer){
+        self.activityCount = 0;
+    }
     self.fadeOutTimer = nil;
     self.imageView.hidden = YES;
     self.maskType = hudMaskType;


### PR DESCRIPTION
It was happen when called  showProgress:status: method after showSuccessWithStatus: method.
In case which next show method is called before starting fadeOutTimer, activityCount was remained +1.
So, fixes to set activityCount to 0 if fadeOutTimer is canceled.