### PR TITLE
Fixed semantic issue obstructing compilation in Objective-C++.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -350,7 +350,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
         CGRect stringRect;
         if ([string respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]){
             stringRect = [string boundingRectWithSize:constraintSize
-                                              options:(NSStringDrawingUsesFontLeading|NSStringDrawingTruncatesLastVisibleLine|NSStringDrawingUsesLineFragmentOrigin)
+                                              options:(NSStringDrawingOptions)(NSStringDrawingUsesFontLeading|NSStringDrawingTruncatesLastVisibleLine|NSStringDrawingUsesLineFragmentOrigin)
                                            attributes:@{NSFontAttributeName: self.stringLabel.font}
                                               context:NULL];
         } else {


### PR DESCRIPTION
It was not possible to compile project in Objective-C++. Now it is.

Compiler was giving this error: "Cannot initialize a parameter of type 'NSStringDrawingOptions' with an rvalue of type 'int'"