### PR TITLE
Carthage build fails on Xcode 6.2

### DIFF
--- a/SVProgressHUD.xcodeproj/project.pbxproj
+++ b/SVProgressHUD.xcodeproj/project.pbxproj
@@ -278,7 +278,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "SVProgressHUD-Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -320,7 +320,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "SVProgressHUD-Framework/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = SVProgressHUD;
@@ -430,6 +430,7 @@
 				4A9D7DED1AB345990039B273 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		65F021F615C857EF0030BBEF /* Build configuration list for PBXProject "SVProgressHUD" */ = {
 			isa = XCConfigurationList;

--- a/SVProgressHUD.xcodeproj/xcshareddata/xcschemes/SVProgressHUD-Framework.xcscheme
+++ b/SVProgressHUD.xcodeproj/xcshareddata/xcschemes/SVProgressHUD-Framework.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4A9D7DD71AB345980039B273"
-               BuildableName = "SVProgressHUD-Framework.framework"
+               BuildableName = "SVProgressHUD.framework"
                BlueprintName = "SVProgressHUD-Framework"
                ReferencedContainer = "container:SVProgressHUD.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4A9D7DD71AB345980039B273"
-            BuildableName = "SVProgressHUD-Framework.framework"
+            BuildableName = "SVProgressHUD.framework"
             BlueprintName = "SVProgressHUD-Framework"
             ReferencedContainer = "container:SVProgressHUD.xcodeproj">
          </BuildableReference>
@@ -76,7 +76,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4A9D7DD71AB345980039B273"
-            BuildableName = "SVProgressHUD-Framework.framework"
+            BuildableName = "SVProgressHUD.framework"
             BlueprintName = "SVProgressHUD-Framework"
             ReferencedContainer = "container:SVProgressHUD.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4A9D7DD71AB345980039B273"
-            BuildableName = "SVProgressHUD-Framework.framework"
+            BuildableName = "SVProgressHUD.framework"
             BlueprintName = "SVProgressHUD-Framework"
             ReferencedContainer = "container:SVProgressHUD.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
Building the iOS framework via Carthage on Xcode 6.2 fails as the deployment target is set to 8.3 (i.e. Xcode 6.3). There don’t appear to be any 8.3-specific requirements, so I’ve set this back to 8.0.