### PR TITLE
Minor code syntax changes.

### DIFF
--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -70,7 +70,7 @@
         
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"transform.rotation"];
         animation.fromValue = 0;
-        animation.toValue = [NSNumber numberWithFloat:M_PI*2];
+        animation.toValue = @(M_PI*2);
         animation.duration = animationDuration;
         animation.timingFunction = linearCurve;
         animation.removedOnCompletion = NO;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -251,12 +251,12 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
 #pragma mark - Instance Methods
 
-- (id)initWithFrame:(CGRect)frame {
+- (instancetype)initWithFrame:(CGRect)frame {
     if ((self = [super initWithFrame:frame])) {
 		self.userInteractionEnabled = NO;
         self.backgroundColor = [UIColor clearColor];
 		self.alpha = 0.0f;
-        self.activityCount = 0;
+        _activityCount = 0;
         
         SVProgressHUDBackgroundColor = [UIColor whiteColor];
         SVProgressHUDForegroundColor = [UIColor blackColor];
@@ -269,7 +269,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
             SVProgressHUDForegroundColor = [UIColor whiteColor];
         }
         
-        NSBundle *bundle = [NSBundle bundleForClass:self.class];
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
         NSURL *url = [bundle URLForResource:@"SVProgressHUD" withExtension:@"bundle"];
         NSBundle *imageBundle = [NSBundle bundleWithURL:url];
         
@@ -495,8 +495,8 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
     if(notification) {
         NSDictionary* keyboardInfo = [notification userInfo];
-        CGRect keyboardFrame = [[keyboardInfo valueForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue];
-        animationDuration = [[keyboardInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+        CGRect keyboardFrame = [keyboardInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+        animationDuration = [keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
         
         if(notification.name == UIKeyboardWillShowNotification || notification.name == UIKeyboardDidShowNotification) {
             if(ignoreOrientation || UIInterfaceOrientationIsPortrait(orientation))
@@ -658,7 +658,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
         self.hudView.isAccessibilityElement = YES;
     }
     
-    [self.overlayView setHidden:NO];
+    self.overlayView.hidden = NO;
     self.overlayView.backgroundColor = [UIColor clearColor];
     [self positionHUD:nil];
     
@@ -718,8 +718,8 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     self.maskType = hudMaskType;
     [self cancelRingLayerAnimation];
     
-    if(![self.class isVisible])
-        [self.class showWithMaskType:self.maskType];
+    if(![[self class] isVisible])
+        [[self class] showWithMaskType:self.maskType];
   
     if ([self.imageView respondsToSelector:@selector(setTintColor:)]) {
         self.imageView.tintColor = SVProgressHUDForegroundColor;


### PR DESCRIPTION
1. Using modern syntax for NSNumber creation.
2. Replacing (id)initWithFrame with (instancetype)initWithFrame.
3. Using ivar access instead of self.property inside of the init method.
4. Harmonized self.class -> [self class] to match NSObject's defined usage.
5. Harmonized setHidden:NO -> .hidden = NO to match usage elsewhere in the project.
6. Using modern dictionary syntax in place of valueForKey.