### PR TITLE
Removes an existing gradient layer if present

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -356,6 +356,10 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 }
 
 - (void)updateMask{
+    if(self.backgroundGradientLayer){
+        [self.backgroundGradientLayer removeFromSuperlayer];
+        self.backgroundGradientLayer = nil;
+    }
     switch (self.maskType) {
         case SVProgressHUDMaskTypeBlack: {
             self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];


### PR DESCRIPTION
If background gradient layer has already been added as a sublayer it should be removed or it would place layer upon layer every time method is called. Or it would case gradient to persist if changing type to "Black".