### PR TITLE
Fix an off-center HUD when running in a Safari extension on the iPad

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -594,8 +594,8 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     self.frame = [UIApplication sharedApplication].keyWindow.bounds;
     UIInterfaceOrientation orientation = UIApplication.sharedApplication.statusBarOrientation;
 #else
-    self.frame = UIScreen.mainScreen.bounds;
     if (self.viewForExtension) self.frame = self.viewForExtension.frame;
+    else self.frame = UIScreen.mainScreen.bounds;
     UIInterfaceOrientation orientation = CGRectGetWidth(self.frame) > CGRectGetHeight(self.frame) ? UIInterfaceOrientationLandscapeLeft : UIInterfaceOrientationPortrait;
 #endif
     

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -595,6 +595,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     UIInterfaceOrientation orientation = UIApplication.sharedApplication.statusBarOrientation;
 #else
     self.frame = UIScreen.mainScreen.bounds;
+    if (self.viewForExtension) self.frame = self.viewForExtension.frame;
     UIInterfaceOrientation orientation = CGRectGetWidth(self.frame) > CGRectGetHeight(self.frame) ? UIInterfaceOrientationLandscapeLeft : UIInterfaceOrientationPortrait;
 #endif
     


### PR DESCRIPTION
Previously, if `viewForExtension` is set, the the window frame will be used to find the center of the screen, which doesn't make sense if the HUD is being positioned in a view that's smaller than the screen. 

For example, trying to show the HUD in a Safari extension on the iPad results in this (that's it down in the bottom right corner):

![2015-10-29 14 25 48](https://cloud.githubusercontent.com/assets/522101/10832604/9ddf01be-7e49-11e5-9d35-aaf2bb1a61c2.png)

I added a line to use the view's frame rather than the screen's frame if a custom view is present.